### PR TITLE
moved discriminator's backward position

### DIFF
--- a/main.py
+++ b/main.py
@@ -94,6 +94,11 @@ def train(epoch):
         d_fake_loss = model.adversarial_loss(d_fake, False, True)
         d_loss += (d_real_loss + d_fake_loss) / 2
 
+        # Backward
+        d_loss.backward()
+        model.dis_optimizer.step()
+        model.dis_optimizer.zero_grad()
+
         g_fake, _ = model.discriminator(prediction)
         g_gan_loss = model.adversarial_loss(g_fake, True, False)
         g_loss += model.gan_weight * g_gan_loss
@@ -110,10 +115,6 @@ def train(epoch):
         avg_d_loss += d_loss.data.item()
 
         # Backward
-        d_loss.backward()
-        model.dis_optimizer.step()
-        model.dis_optimizer.zero_grad()
-
         g_loss.backward()
         model.gen_optimizer.step()
         model.gen_optimizer.zero_grad()


### PR DESCRIPTION
There was an "inplace operation error " (shown in img) with old code, possibly because the forward of the discriminator was called twice prior to backward (maybe retaing_graph = True was another workaround)
![rn_pr](https://user-images.githubusercontent.com/17708197/101295305-80284400-3825-11eb-9b95-0be434aa57e6.png)
